### PR TITLE
Fix `--export` command line example

### DIFF
--- a/_posts/2014-11-26-gpg-for-humans-protecting-your-primary-key.markdown
+++ b/_posts/2014-11-26-gpg-for-humans-protecting-your-primary-key.markdown
@@ -88,7 +88,7 @@ Success! Note that there's now a primary key - `pub` - and two subkeys - `sec`. 
 
 At this point we can make a **full** copy (backup) of our keyring (primary and subkeys, public and secret parts):
 
-    $ gpg --export --armor 0x309F635DAD1B5517 > 0x309F635DAD1B5517.full_backup.asc
+    $ gpg --export-secret-keys --armor 0x309F635DAD1B5517 > 0x309F635DAD1B5517.full_backup.asc
 
 
 ### Create a Partial Backup (Subkeys)


### PR DESCRIPTION
In this line I'm showing how to create a _full_ backup (public & private keys)
but the `--export` command only exports the public keys.

Note that the GnuPG manual is pretty confusing in this respect:

```
--export
Either export all keys from all keyrings (default keyrings  and
those  registered via option --keyring), or if at least one name is
given, those of the given name. The new keyring is written to STDOUT  or
to the file given with option --output. Use together with --armor to
mail those keys.
```

... but actually _all_ keys really means all _public_ keys.

```
--export-secret-keys
--export-secret-subkeys
Same  as --export, but exports the secret keys instead.  This is
normally not very useful and a security risk.  The  second form of  the
command  has  the special property to render the secret part of the
primary key useless; this  is  a  GNU extension  to OpenPGP  and  other
implementations can not be expected to suc‐ cessfully import such a key.
See the option --simple-sk-check‐ sum  if  you  want  to import such an
exported key with an older OpenPGP implementation.
```

... and confusingly, _secret keys_ means _public AND secret keys_.

Meh.
