### PR TITLE
Fix invalid RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+title: "Paul M Furley, developer"
 gems:
   - jekyll-redirect-from
   - jekyll-feed

--- a/_posts/2014-11-11-gpg-for-humans-public-key-crypto-primer.markdown
+++ b/_posts/2014-11-11-gpg-for-humans-public-key-crypto-primer.markdown
@@ -7,7 +7,10 @@ sfw_pwd:
   - of6Qwpv4RDVy
 category: gpgforhumans
 ---
-Public-key or "asymmetric" crypto is a cunning piece of maths (which I happily don't understand) that's at the heart of GPG. The incredible thing it allows is for us to communicate securely (signing & encryption) without having agreed a secret in advance. This turns out to be a big deal.
+Public-key or "asymmetric" crypto is a cunning piece of maths (which I happily
+don't understand) that's at the heart of GPG. The incredible thing it allows is
+for us to communicate securely (signing and encryption) without having agreed a
+secret in advance. This turns out to be a big deal.
 
 In GPG you create a *pair* of keys which are fundamentally related. One half is your *secret* or *private* key, which you keep strictly to yourself. The other half is your *public* key which you tell everyone about, if you so wish.
 

--- a/_posts/2015-09-27-my-barcamp-2015-highlights.markdown
+++ b/_posts/2015-09-27-my-barcamp-2015-highlights.markdown
@@ -2,7 +2,9 @@
 title: "My Barcamp 2015 Highlights"
 ---
 
-I've just parted ways with a friendly & interesting bunch of people - exactly what I'd expect from a Barcamp crowd. This was my second Barcamp and it was fab to go with a bit more understanding of what to expect and how it works.
+I've just parted ways with a friendly and interesting bunch of people - exactly
+what I'd expect from a Barcamp crowd. This was my second Barcamp and it was fab
+to go with a bit more understanding of what to expect and how it works.
 
 In case you aren't familiar, Barcamp is an unconference. There are no scheduled speakers - that's the job of the Barcampers, and everyone's encouraged to give a talk.
 


### PR DESCRIPTION
- Fix HTML summary in two blog posts
  It seems that https://github.com/jekyll/jekyll-feed creates invalid
  `<summary>` tags if the first paragraph of a blog post contains an
  ampersand:
  
  """ summary should not contain HTML unless declared in the type attribute:
  &amp;
  """
- Add `title`

Fixes #33
